### PR TITLE
v4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 ## Changelog
 
+- v5.0
+
+  - New
+
+    - You can right click on the Potential Links found list, and if `Show origin endpoint` is unchecked and `In scope only` is checked, you can select `Request all prefixed URLs and send to Site Map`. This will request all URLs shown in the current pane (so can be filtered with `Link filter` too) and make a GET request for each URL. The URLs will be requested in 2 separate threads, with 10 milliseconds between each request, and they will be added to the Site Map.
+    - When requests are being made, you can right click on the Potential Links found list and select the `Cancel all requests being made` menu item to stop all requests previously scheduled.
+    - If a link found ends with a `.` or `|`, then they will be removed.
+    - If a link found has literal `\n` or `\r` in it, then it will be stripped from the first occurrence.
+    - When checking if a link is valid, check if it has a host and it is a valid host. This will remove false positives like `alert(e.which)` for example.
+
+  - Changed
+
+    - Change code that looked for a closed bracket without an open one, for better code that checks for unbalanced brackets, and strips from the unbalanced closing bracket.
+    - Change `getResponseLinks` to prevent runtime errors happening when the link gets set to blank.
+    - Remove a print statement accidentally left in when copying to the clipboard.
+
 - v4.9
 
   - New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Changelog
 
+- v4.9
+
+  - New
+
+    - You can click the progress bar to see a modal dialog box showing the datetime of the last run, with the context GAP was run from (e.g. `Target Site Map Tree`, `Proxy History`, etc.) and a list of Hosts. For all contexts other than `Target Site Map Tree`, there will be a `Show hosts only` check box (defaults to checked). If unchecked, then a list of unique target URLs are displayed instead.
+    - You can now right click on the params, words and links pane and click the `Copy` link to copy the contents of that pane to the clipboard. For "sus" parameters view, the parameters will be copied without the vulnerability types in square brackets after them.
+    - If GAP is called from the Site Map tree context, then Scope has to be set to work. This can often make people think GAP isn't working correctly. So, if run from this context and no content is found, and additional message is given in the output pane(s) saying `Maybe scope isn't set? It needs to be set to call GAP from the Site Map tree. Ignore this if there are results for other modes.`
+
+  - Changed
+
+    - Change the progress bar tooltip text to `Click to see execution scope. When running, this shows what request is being processed out of the total number of requests for current target.`
+
 - v4.8
 
   - New

--- a/GAP Help.md
+++ b/GAP Help.md
@@ -116,13 +116,13 @@ In addition to the options above, words will be taken from all responses with ce
 </ul>
 
 <h1>GAP Output</h1>
-Below is an explanation of the output given when GAP has completed running.
+Below is an explanation of the output given when GAP has completed running. When running has been completed, you can click the right mouse button in the parameter, words or links pane to get a <code>Copy</code> link. Clicking this will copy whatever is in the pane to your clipboard.
 
 <h2>Potential Parameters</h2>
 <ul>
 <li><b>Potential parameters found</b> - This text are will show all unique potential parameters, one per line.</li>
 <li><b>Show origin</b> - If this feature is ticked, the potential parameter will be followed by the HTTP request endpoint (in square brackets) that the parameter was found in. A parameter could have been found in more than one request, so this view can show duplicate links, one per origin endpoint.</li>
-<li><b>Show "sus"</b> - If this feature is ticked, only potential parameters that are "sus" are shown followed by the associated vulnerability type(s) (in square brackets).</li>
+<li><b>Show "sus"</b> - If this feature is ticked, only potential parameters that are "sus" are shown followed by the associated vulnerability type(s) (in square brackets). <b>NOTE: If you right click and select <code>Copy</code> you will have the parameter names WITHOUT the vuln types copied to your clipboard.</b>></li>
 <li><b>Show query string with value</b> - This checkbox can be used to switch between the list of parameters and a concatenated query string with all parameters with a value given in the following text box.</li>
 <li><b>Param Value</b> - This defaults to XNLV and is a value that is used to create the concatenated query string, with each parameter given this value followed by a unique number of the parameter. This query string can be used to manually append to a URL and check for reflections.</li>
 </ul>

--- a/GAP Help.md
+++ b/GAP Help.md
@@ -122,7 +122,7 @@ Below is an explanation of the output given when GAP has completed running. When
 <ul>
 <li><b>Potential parameters found</b> - This text are will show all unique potential parameters, one per line.</li>
 <li><b>Show origin</b> - If this feature is ticked, the potential parameter will be followed by the HTTP request endpoint (in square brackets) that the parameter was found in. A parameter could have been found in more than one request, so this view can show duplicate links, one per origin endpoint.</li>
-<li><b>Show "sus"</b> - If this feature is ticked, only potential parameters that are "sus" are shown followed by the associated vulnerability type(s) (in square brackets). <b>NOTE: If you right click and select <code>Copy</code> you will have the parameter names WITHOUT the vuln types copied to your clipboard.</b>></li>
+<li><b>Show "sus"</b> - If this feature is ticked, only potential parameters that are "sus" are shown followed by the associated vulnerability type(s) (in square brackets). <b>NOTE: If you right click and select <code>Copy</code> you will have the parameter names WITHOUT the vuln types copied to your clipboard.</b></li>
 <li><b>Show query string with value</b> - This checkbox can be used to switch between the list of parameters and a concatenated query string with all parameters with a value given in the following text box.</li>
 <li><b>Param Value</b> - This defaults to XNLV and is a value that is used to create the concatenated query string, with each parameter given this value followed by a unique number of the parameter. This query string can be used to manually append to a URL and check for reflections.</li>
 </ul>
@@ -140,6 +140,10 @@ The filter is something that is applied after GAP has run. It allows you to look
 An additional feature of GAP is to automatically include links of valid <code>.js.map</code> (javascript source map) files. These are identified by responses that contain the <code>//# sourceMappingURL</code> line, or have a HTTP header of <code>SourceMap</code> or <code>X-SourceMap</code>.<br>
 <br>
 To find links, a complex regex is used to look for different formats and contexts for potential links and files. This regex was initially based on the one used in <b>Link Finder</b> by Gerben Javado, but has been evolved to try and identify more with minimal false positives.<br>
+<br>
+If you have the <b>Show origin endpoint</b> options unchecked and the <b>In scope only</b> option checked, then when you right click the pane, you will get another menu option of <b>Request all prefixed URLs and send to Site Map</b>. Clicking this will request all URLs shown in the current pane (so can be filtered with <b>Link filter</b> too) and make a <code>GET</code> request for each URL. The URLs will be requested in 2 separate threads, with 10 milliseconds between each request, and they will be added to the <b>Site Map</b>.<br>
+<b>NOTE: Sometimes java errors can be written to the extensions Error tab if a hoist is unreachable. There doesn't seem to be a way to catch these, but they can be safely ignored.</b><br>
+When requests are being made, you can right click on the pane and select the <b>Cancel all requests being made</b> menu item to stop all requests previously scheduled.<br>
 <h2>Words</h2>
 <ul>
 <li><b>Words found</b> - This text are will show all unique words, one per line.</li>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <center><img src="https://raw.githubusercontent.com/xnl-h4ck3r/GAP-Burp-Extension/main/GAP/images/title.png"></center>
 
-## About - v4.9
+## About - v5.0
 
 This is an evolution of the original getAllParams extension for Burp. Not only does it find more potential parameters for you to investigate, but it also finds potential links to try these parameters on, and produces a target specific wordlist to use for fuzzing.
 The full Help documentation can be found [here](https://github.com/xnl-h4ck3r/burp-extensions/blob/main/GAP%20Help.md) or from the Help icon on the GAP tab.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <center><img src="https://raw.githubusercontent.com/xnl-h4ck3r/GAP-Burp-Extension/main/GAP/images/title.png"></center>
 
-## About - v4.8
+## About - v4.9
 
 This is an evolution of the original getAllParams extension for Burp. Not only does it find more potential parameters for you to investigate, but it also finds potential links to try these parameters on, and produces a target specific wordlist to use for fuzzing.
 The full Help documentation can be found [here](https://github.com/xnl-h4ck3r/burp-extensions/blob/main/GAP%20Help.md) or from the Help icon on the GAP tab.


### PR DESCRIPTION
- New

    - You can click the progress bar to see a modal dialog box showing the datetime of the last run, with the context GAP was run from (e.g. `Target Site Map Tree`, `Proxy History`, etc.) and a list of Hosts. For all contexts other than `Target Site Map Tree`, there will be a `Show hosts only` check box (defaults to checked). If unchecked, then a list of unique target URLs are displayed instead.
    - You can now right click on the params, words and links pane and click the `Copy` link to copy the contents of that pane to the clipboard. For "sus" parameters view, the parameters will be copied without the vulnerability types in square brackets after them.
    - If GAP is called from the Site Map tree context, then Scope has to be set to work. This can often make people think GAP isn't working correctly. So, if run from this context and no content is found, and additional message is given in the output pane(s) saying `Maybe scope isn't set? It needs to be set to call GAP from the Site Map tree. Ignore this if there are results for other modes.`

  - Changed

    - Change the progress bar tooltip text to `Click to see execution scope. When running, this shows what request is being processed out of the total number of requests for current target.`