### PR TITLE
v5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 ## Changelog
 
+- v5.5
+
+  - New
+
+    - Add a `COMMON_TLDS` list. This can't be edited through the UI at the moment, but can be changed in the code if required.
+    - Perform a separate regex search for links that can potentially get lots of false positives, but validate these by checking the TLD for the link is valid. The following will NOT be returned:
+      - invalid domains (TLDs that don't exist)
+      - domain with less than 3 chars before tld
+      - domain doesn't start with `_`
+      - suffix `call`,`skin`,`menu`,`style`,`rest`,`next`
+      - domains `this`,`self`,`target`,`value`,`values`,`prop`,`properties`,`proparray`,`useragent`,`rect`,`paddiing`,`style`,`rule`,`bound`,`child`,`global`,`element`,`div`,`prototype`,`event`,`feature`,`path`
+      - suffix is `js` and domain is NOT `map`
+      - domains with TLDs that aren't in the `COMMON_TLDS` list
+    - Before searching for links, replace different encodings of double quotes with `"` to maximise the number of links found.
+    - Remove any base64 encoded strings over 10,000 characters long (that match regex `eyJ[a-zA-Z0-9\+\/]+(?:=|\b|\n)`). There are some responses that can have huge ones and ends up causing regex problems and hanging.
+    - Don't include any links that start with a `-`.
+
+  - Changed
+
+    - Update the latest version of the Jython `.jar` file in `README.md` and `GAP Help.md`.
+    - Update the `pip install` command in the installation instructions to use `--no-cache-dir --no-compile`. This resolved an issue I had trying to install `tldextract`.
+
 - v5.4
 
   - Changed

--- a/GAP Help.md
+++ b/GAP Help.md
@@ -10,11 +10,11 @@ A shout out to Gerben Javado and his amazing tool <b>Link Finder</b> who's regul
 
 <h1>How to Install</h1>
 <ol>
-<li>Visit <a href="https://www.jython.org/download">Jython Offical Site</a>, and download the latest stand alone JAR file, e.g. <code>jython-standalone-2.7.3.jar</code>.</li>
+<li>Visit <a href="https://www.jython.org/download">Jython Offical Site</a>, and download the latest stand alone JAR file, e.g. <code>jython-standalone-2.7.4.jar</code>.</li>
 <li>Open Burp, go to <b>Extensions</b> -> <b>Extension Settings</b> -> <b>Python Environment</b>, set the <b>Location of Jython standalone JAR file</b> and <b>Folder for loading modules</b> to the directory where the Jython JAR file was saved.</li>
-<li>On a command line, go to the directory where the jar file is and run <code>java -jar jython-standalone-2.7.3.jar -m ensurepip</code>.</li>
+<li>On a command line, go to the directory where the jar file is and run <code>java -jar jython-standalone-2.7.4.jar -m ensurepip</code>.</li>
 <li>Download the <code>GAP.py</code> and <code>requirements.txt</code> from this project and place in the same directory.</li>
-<li>Install Jython modules by running <code>java -jar jython-standalone-2.7.3.jar -m pip install -r requirements.txt</code>.</li>
+<li>Install Jython modules by running <code>java -jar jython-standalone-2.7.4.jar -m pip install --no-cache-dir --no-compile -r requirements.txt</code>.</li>
 <li>Go to the <b>Extensions</b> -> <b>Installed</b> and click <b>Add</b> under <b>Burp Extensions</b>.
 <li>Set <b>Extension type</b> to <b>Python</b> and select the <code>GAP.py</code> file</li>
 <li>Click <b>Next</b> and you're good to go <b>&#129304;</b></i>
@@ -183,9 +183,9 @@ If you run GAP for one or more targets from the Site Map view, don't have them e
 
 If you want to run GAP on one of more specific requests, do not select them from the Site Map tree view. It will be a lot quicker to run it from the Site Map Contents view if possible, or from proxy history.
 
-It is hard to design GAP to display all controls for all screen resolutions and font sizes. I have tried to deal with the most common setups, but if you find you cannot see all the controls, you can hold down the `Ctrl` button and click the GAP logo header image to remove it to make more space.</p>
+It is hard to design GAP to display all controls for all screen resolutions and font sizes. I have tried to deal with the most common setups, but if you find you cannot see all the controls, you can hold down the <code>Ctrl</code> button and click the GAP logo header image to remove it to make more space.</p>
 
-<p><p>
+<p>
 <h1></h1>
 Thank you for trying out GAP!<br>
 Good luck and good hunting!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <center><img src="https://raw.githubusercontent.com/xnl-h4ck3r/GAP-Burp-Extension/main/GAP/images/title.png"></center>
 
-## About - v5.4
+## About - v5.5
 
 This is an evolution of the original getAllParams extension for Burp. Not only does it find more potential parameters for you to investigate, but it also finds potential links to try these parameters on, and produces a target specific wordlist to use for fuzzing.
 The full Help documentation can be found [here](https://github.com/xnl-h4ck3r/burp-extensions/blob/main/GAP%20Help.md) or from the Help icon on the GAP tab.
@@ -9,11 +9,11 @@ The full Help documentation can be found [here](https://github.com/xnl-h4ck3r/bu
 
 ### Installation
 
-1. Visit [Jython Offical Site](https://www.jython.org/download), and download the latest stand alone JAR file, e.g. `jython-standalone-2.7.3.jar`.
+1. Visit [Jython Offical Site](https://www.jython.org/download), and download the latest stand alone JAR file, e.g. `jython-standalone-2.7.4.jar`.
 2. Open Burp, go to **Extensions** -> **Extension Settings** -> **Python Environment**, set the **Location of Jython standalone JAR file** and **Folder for loading modules** to the directory where the Jython JAR file was saved.
-3. On a command line, go to the directory where the jar file is and run `java -jar jython-standalone-2.7.3.jar -m ensurepip`.
+3. On a command line, go to the directory where the jar file is and run `java -jar jython-standalone-2.7.4.jar -m ensurepip`.
 4. Download the `GAP.py` and `requirements.txt` from this project and place in the same directory.
-5. Install Jython modules by running `java -jar jython-standalone-2.7.3.jar -m pip install -r requirements.txt`.
+5. Install Jython modules by running `java -jar jython-standalone-2.7.4.jar -m pip install --no-cache-dir --no-compile -r requirements.txt`.
 6. Go to the **Extensions** -> **Installed** and click **Add** under **Burp Extensions**.
 7. Select **Extension type** of **Python** and select the **GAP.py** file.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 beautifulsoup4
 html5lib
 urllib3
-tldextract=2.2.3
+tldextract==2.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 beautifulsoup4
 html5lib
 urllib3
+tldextract=2.2.3


### PR DESCRIPTION
- v5.5

  - New

    - Add a `COMMON_TLDS` list. This can't be edited through the UI at the moment, but can be changed in the code if required.
    - Perform a separate regex search for links that can potentially get lots of false positives, but validate these by checking the TLD for the link is valid. The following will NOT be returned:
      - invalid domains (TLDs that don't exist)
      - domain with less than 3 chars before tld
      - domain doesn't start with `_`
      - suffix `call`,`skin`,`menu`,`style`,`rest`,`next`
      - domains `this`,`self`,`target`,`value`,`values`,`prop`,`properties`,`proparray`,`useragent`,`rect`,`paddiing`,`style`,`rule`,`bound`,`child`,`global`,`element`,`div`,`prototype`,`event`,`feature`,`path`
      - suffix is `js` and domain is NOT `map`
      - domains with TLDs that aren't in the `COMMON_TLDS` list
    - Before searching for links, replace different encodings of double quotes with `"` to maximise the number of links found.
    - Remove any base64 encoded strings over 10,000 characters long (that match regex `eyJ[a-zA-Z0-9\+\/]+(?:=|\b|\n)`). There are some responses that can have huge ones and ends up causing regex problems and hanging.
    - Don't include any links that start with a `-`.

  - Changed

    - Update the latest version of the Jython `.jar` file in `README.md` and `GAP Help.md`.
    - Update the `pip install` command in the installation instructions to use `--no-cache-dir --no-compile`. This resolved an issue I had trying to install `tldextract`.