### PR TITLE
v6.1 and v6.2 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Changelog
 
+- v6.1
+
+  - Changed
+
+    - Amend the `self.REGEX_LINKS_EXTRA` to also check for unicode characters and `%` symbol, so it will also pick up domains like `thisätest.com` and `this%C3%A4test.com`.
+    - Fixed catastrophic backtracking in both the main link regex and domain regex by replacing all unbounded quantifiers (`*` and `{0,}`) with reasonable bounded limits (`{0,500}` or `{0,1000}`). This eliminates regex timeout issues that were occurring on large responses (180KB+), particularly those with special characters or multilingual content. The changes maintain full link discovery capabilities while preventing exponential backtracking that causes timeouts.
+    - Added intelligent content chunking for large responses (>50KB). Large response bodies are now automatically split into overlapping 40KB chunks before regex processing, with 5KB overlap to ensure no matches are missed at chunk boundaries. This provides defense-in-depth protection against performance issues on extreme edge cases while maintaining complete link discovery.
+    - Format code to comply with black and ruff checks.
+    
 - v6.0
 
   - New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+- v6.2
+
+  - Changed
+
+    - Change `DEFAULT_REGEX_TIMEOUT` to 30 seconds. It was intended as that but was accidentally set to 45 in previous testing.
+
 - v6.1
 
   - Changed

--- a/GAP.py
+++ b/GAP.py
@@ -9,7 +9,7 @@ Get full instructions at https://github.com/xnl-h4ck3r/GAP-Burp-Extension/blob/m
 Good luck and good hunting! If you really love the tool (or any others), or they helped you find an awesome bounty, consider BUYING ME A COFFEE! (https://ko-fi.com/xnlh4ck3r) (I could use the caffeine!)
 """
 
-VERSION = "6.1"
+VERSION = "6.2"
 
 _debug = False
 
@@ -497,7 +497,7 @@ SUS_MASSASSIGNMENT = [
 ]
 
 # The number of seconds to wait for a regex query to complete when searching for links
-DEFAULT_REGEX_TIMEOUT = 45
+DEFAULT_REGEX_TIMEOUT = 30
 
 # Chunk large responses to prevent regex timeouts on extreme cases
 # If response body is larger than this, split into chunks (in bytes)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <center><img src="https://raw.githubusercontent.com/xnl-h4ck3r/GAP-Burp-Extension/main/GAP/images/title.png"></center>
 
-## About - v6.1
+## About - v6.2
 
 This is an evolution of the original getAllParams extension for Burp. Not only does it find more potential parameters for you to investigate, but it also finds potential links to try these parameters on, and produces a target specific wordlist to use for fuzzing.
 The full Help documentation can be found [here](https://github.com/xnl-h4ck3r/burp-extensions/blob/main/GAP%20Help.md) or from the Help icon on the GAP tab.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <center><img src="https://raw.githubusercontent.com/xnl-h4ck3r/GAP-Burp-Extension/main/GAP/images/title.png"></center>
 
-## About - v6.0
+## About - v6.1
 
 This is an evolution of the original getAllParams extension for Burp. Not only does it find more potential parameters for you to investigate, but it also finds potential links to try these parameters on, and produces a target specific wordlist to use for fuzzing.
 The full Help documentation can be found [here](https://github.com/xnl-h4ck3r/burp-extensions/blob/main/GAP%20Help.md) or from the Help icon on the GAP tab.


### PR DESCRIPTION
- v6.2

  - Changed

    - Change `DEFAULT_REGEX_TIMEOUT` to 30 seconds. It was intended as that but was accidentally set to 45 in previous testing.

- v6.1

  - Changed

    - Amend the `self.REGEX_LINKS_EXTRA` to also check for unicode characters and `%` symbol, so it will also pick up domains like `thisätest.com` and `this%C3%A4test.com`.
    - Fixed catastrophic backtracking in both the main link regex and domain regex by replacing all unbounded quantifiers (`*` and `{0,}`) with reasonable bounded limits (`{0,500}` or `{0,1000}`). This eliminates regex timeout issues that were occurring on large responses (180KB+), particularly those with special characters or multilingual content. The changes maintain full link discovery capabilities while preventing exponential backtracking that causes timeouts.
    - Added intelligent content chunking for large responses (>50KB). Large response bodies are now automatically split into overlapping 40KB chunks before regex processing, with 5KB overlap to ensure no matches are missed at chunk boundaries. This provides defense-in-depth protection against performance issues on extreme edge cases while maintaining complete link discovery.
    - Format code to comply with black and ruff checks.